### PR TITLE
Dev seeall noclip command

### DIFF
--- a/gamemode/core/commands/sh_admin.lua
+++ b/gamemode/core/commands/sh_admin.lua
@@ -302,7 +302,6 @@ end, COMMAND_ADMIN, {}, {CFLAG_NOCONSOLE},
 "Sandbox", "Saves the prop or effect you're looking at, making it unable to be edited and persist through restarts/map changes.")
 
 console.AddCommand("rpa_seeall", function(ply)
-	ply:SetSetting("seeall_enabled", not ply:GetSetting("seeall_enabled"))
 end, COMMAND_ADMIN, {}, {CFLAG_NOCONSOLE},
 "Clientside", "Toggles seeall on or off.")
 

--- a/gamemode/core/commands/sh_admin.lua
+++ b/gamemode/core/commands/sh_admin.lua
@@ -302,6 +302,15 @@ end, COMMAND_ADMIN, {}, {CFLAG_NOCONSOLE},
 "Sandbox", "Saves the prop or effect you're looking at, making it unable to be edited and persist through restarts/map changes.")
 
 console.AddCommand("rpa_seeall", function(ply)
+	local noclipseeall = GAMEMODE:NoclipSeeall()
+
+	if ply:IsInNoClip() and noclipseeall == true or noclipseeall == false then
+		ply:SetSetting("seeall_enabled", not ply:GetSetting("seeall_enabled"))
+		GAMEMODE:WriteLog("admin_seeall", {
+			Admin = GAMEMODE:LogPlayer(ply)
+		})
+	end
+
 end, COMMAND_ADMIN, {}, {CFLAG_NOCONSOLE},
 "Clientside", "Toggles seeall on or off.")
 

--- a/gamemode/core/commands/sh_superadmin.lua
+++ b/gamemode/core/commands/sh_superadmin.lua
@@ -129,3 +129,22 @@ console.AddCommand("rpa_takemoney", function(ply, targets, amount)
 	Feedback(ply, string.format("You've taken %s credits from %s", amount, TargetName(targets, "RPName")))
 end, COMMAND_SA, {CTYPE_PLAYER, CTYPE_NUMBER}, {},
 "Superadmin", "Takes money from a player.")
+
+console.AddCommand("rpa_noclipseeall", function(ply)
+	GAMEMODE:SetNoclipSeeall(not GAMEMODE:NoclipSeeall())
+	GAMEMODE:WriteLog("admin_noclipseeall", {
+		Admin = GAMEMODE:LogPlayer(ply)
+	})
+
+	if GAMEMODE:NoclipSeeall() == true then -- Disable seeall for players currently not in noclip
+		local players = player.GetHumans()
+		for _, v in ipairs(players) do
+			if v:GetSetting("seeall_enabled") and not v:IsInNoClip() then
+				v:SetSetting("seeall_enabled", false)
+				Feedback(v, "Seeall has been disabled outside of noclip, turning off your seeall.")
+			end
+		end
+	end
+
+end, COMMAND_SA, {}, {CFLAG_NOCONSOLE},
+"Superadmin", "Toggles whether admins can use seeall only when in NoClip.")

--- a/gamemode/core/logtypes/sh_admin.lua
+++ b/gamemode/core/logtypes/sh_admin.lua
@@ -42,6 +42,10 @@ GM:RegisterLogType("admin_license", LOG_ADMIN, function(data)
 	end
 end)
 
+GM:RegisterLogType("admin_seeall", LOG_ADMIN, function(data)
+	return string.format("%s has toggled seeall", GAMEMODE:FormatPlayer(data.Admin))
+end)
+
 GM:RegisterLogType("admin_permission", LOG_ADMIN, function(data)
 	local name = string.lower(PERMISSIONS[data.Perm].Name)
 
@@ -198,4 +202,12 @@ end)
 
 GM:RegisterLogType("admin_mapbutton", LOG_ADMIN, function(data)
 		return string.format("%s has triggered %s", GAMEMODE:FormatPlayer(data.Admin), string.lower(data.Button))
+end)
+
+GM:RegisterLogType("admin_noclipseeall", LOG_ADMIN, function(data)
+		return string.format("%s has toggled NoClip seeall. NoClip seeall status is now %s", GAMEMODE:FormatPlayer(data.Admin), GAMEMODE:NoclipSeeall())
+end)
+
+GM:RegisterLogType("admin_disabledseeall", LOG_ADMIN, function(data)
+		return string.format("Seeall disabled for %s", GAMEMODE:FormatPlayer(data.Admin))
 end)

--- a/gamemode/core/sh_global.lua
+++ b/gamemode/core/sh_global.lua
@@ -1,2 +1,3 @@
 accessor.Global("OOCDelay", 0, ACCESSOR_SHARED)
 accessor.Global("WorldArea", WORLDAREA_NONE, ACCESSOR_SHARED)
+accessor.Global("NoclipSeeall", false, ACCESSOR_SHARED)


### PR DESCRIPTION
Added a command (`rpa_noclipseeall`) for superadmins to toggle whether admins can use seeall only in noclip or not.

By default this is set to false, so admins can use `rpa_seeall` at any time regardless of noclip after a server restart.

`rpa_noclipseeall` is only available to superadmins.

When rpa_noclipseeall is run, any players not in noclip with seeall enabled will have it disabled, and be shown a prompt to that effect.

The `rpa_seeall` command has no effect if the player is out of noclip and noclipseeall is set to true.