### PR TITLE
Dev permaprop limit

### DIFF
--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -25,6 +25,8 @@ GM.Config.UIColors = {
 	ItemAllow = Color(40, 150, 20),
 }
 
+GM.Config.PermaPropLimit = 3
+
 GM.Config.MaxCharacters = 20
 
 GM.Config.MinNameLength = 3

--- a/gamemode/core/commands/sh_admin.lua
+++ b/gamemode/core/commands/sh_admin.lua
@@ -269,7 +269,18 @@ console.AddCommand("rpa_togglesaved", function(ply)
 		return
 	end
 
-	ent:SetPermaProp(not ent:PermaProp())
+	if permaprops_in_session < GAMEMODE:GetConfig("PermaPropLimit") then
+		ent:SetPermaProp(not ent:PermaProp())
+		if ent:PermaProp() then
+			permaprops_in_session = permaprops_in_session + 1 -- Keep track of the changed number of permaprops
+		else
+			permaprops_in_session = permaprops_in_session - 1 -- Keep track of the changed number of permaprops
+		end
+	else -- Disable saving if the limit has been exceeded, only remove.
+		ent:SetPermaProp(false)
+		permaprops_in_session = permaprops_in_session - 1 -- Keep track of the changed number of permaprops
+		Feedback(ply, string.format("Permaprop limit has been reached! Removing permaprop %s.", ent:GetModel()))
+	end
 
 	undo.ReplaceEntity(ent, NULL)
 	cleanup.ReplaceEntity(ent, NULL)

--- a/gamemode/core/sh_items.lua
+++ b/gamemode/core/sh_items.lua
@@ -30,7 +30,7 @@ function GM:LoadItems()
 	-- Weapons
 	self:RegisterItemFolder("items/weapons")
 
-	log.Default("[mounting] Registering items from custom mopdules")
+	log.Default("[mounting] Registering items from custom modules")
 
 	hook.Run("EternityPostLoadItems")
 end

--- a/gamemode/core/sv_sandbox.lua
+++ b/gamemode/core/sv_sandbox.lua
@@ -440,7 +440,10 @@ function GM:LoadPermaProps()
 		file.Write(string.format("eternity/permaprops/%s.txt", game.GetMap()), pon.encode(entities))
 	end
 
+	local limit = GAMEMODE:GetConfig("PermaPropLimit")
+	local count = 0
 	for _, data in next, entities do
+		if count >= limit then break end
 		if !PERMAPROP_CLASSES[data.Class] then continue end
 
 		local ent = ents.Create(data.Class)
@@ -530,6 +533,7 @@ function GM:LoadPermaProps()
 		end
 
 		ent:SetPermaProp(true)
+		count = count + 1
 	end
 end
 

--- a/gamemode/core/sv_sandbox.lua
+++ b/gamemode/core/sv_sandbox.lua
@@ -441,9 +441,8 @@ function GM:LoadPermaProps()
 	end
 
 	local limit = GAMEMODE:GetConfig("PermaPropLimit")
-	local count = 0
+	permaprops_in_session = 0 -- referenced in rpa_togglesaved
 	for _, data in next, entities do
-		if count >= limit then break end
 		if !PERMAPROP_CLASSES[data.Class] then continue end
 
 		local ent = ents.Create(data.Class)
@@ -533,7 +532,13 @@ function GM:LoadPermaProps()
 		end
 
 		ent:SetPermaProp(true)
-		count = count + 1
+		permaprops_in_session = permaprops_in_session + 1 -- Save a total of how many permaprops there are. This will be referenced against the limit
+	end
+	log.Default(string.format("[PERMAPROPS] %s permaprops loaded", permaprops_in_session))
+	if permaprops_in_session >= limit then
+		local permaprops_exceeded_amount = permaprops_in_session - limit
+		log.Default(string.format("[PERMAPROPS] Warning! Permaprops loaded this session exceed the server-level configured \z
+			limit of %s by %s! It will not be possible to add new permaprops until these have been removed or the limit is changed.", limit, permaprops_exceeded_amount))
 	end
 end
 


### PR DESCRIPTION
Added a config item that allows the server admin to set a permaprop limit.

Permaprops are all loaded in regardless of whether there are more to load than the limit, but if the limit is reached is impossible to add new permaprops, only remove.

The console will throw a warning if the limit is exceeded.

rpa_togglesaved now tracks the number of permaprops as it adds and removes.

Fixed a typo in sh_items.lua